### PR TITLE
fix: wayland, cpu 100%, tmp workaround

### DIFF
--- a/src/master/wayland.rs
+++ b/src/master/wayland.rs
@@ -126,10 +126,15 @@ impl WlClipboardListener {
                             self.copied = false;
                             break;
                         }
+                    } else {
+                        // https://docs.rs/wayland-backend/latest/wayland_backend/rs/client/struct.ReadEventsGuard.html#method.read
+                        // It's wired that `read()` return `Ok(0)` if `winit` is in `Cargo.tomml`.
+                        // https://github.com/rust-windowing/winit/issues/4380
+                        std::thread::sleep(std::time::Duration::from_millis(30));
                     }
                 }
                 Err(WaylandError::Io(ref e)) if e.kind() == io::ErrorKind::WouldBlock => {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
+                    std::thread::sleep(std::time::Duration::from_millis(30));
                 }
                 Err(e) => {
                     return Err(io::Error::new(


### PR DESCRIPTION
Try to fix CPU 100% on Wayland. https://github.com/rustdesk/rustdesk/discussions/12548

GNOME Wayland way not have this issue, because `WAYLAND_DISPLAY` is not set.

https://github.com/rustdesk-org/clipboard-master/blob/4fb62e5b62fb6350d82b571ec7ba94b3cd466695/src/master/x11.rs#L285

Related report https://github.com/rust-windowing/winit/issues/4380


## Tests

`RustDesk A` -> `RustDesk Wayland` -> `RustDesk B`: **Copy&Paste** works fine even `winit` is in `Cargo.toml`.
