### PR TITLE
Feat/ext data control v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ windows-win = "3"
 x11-clipboard = "0.9"
 x11rb = { version = "0.13", features = ["xfixes"] }
 wl-clipboard-rs = { version = "0.9" }
-wayland-protocols = { version = "0.32.2", default-features = false, features = [
+wayland-protocols = { version = "0.32.6", default-features = false, features = [
 	"unstable",
+	"staging",
 	"client",
 ] }
 wayland-protocols-wlr = { version = "0.3.2", default-features = false, features = [

--- a/src/master/wayland.rs
+++ b/src/master/wayland.rs
@@ -46,6 +46,7 @@ pub(crate) struct WlClipboardListener {
     seat_name: Option<String>,
     data_manager: Option<DataControlManager>,
     data_device: Option<DataControlDevice>,
+    terminated_reason: Option<&'static str>,
     mime_types: Vec<String>,
     queue: Option<Arc<Mutex<EventQueue<Self>>>>,
     exit_flag: Arc<AtomicBool>,
@@ -70,6 +71,7 @@ impl WlClipboardListener {
             seat_name: None,
             data_manager: None,
             data_device: None,
+            terminated_reason: None,
             mime_types: Vec::new(),
             queue: None,
             exit_flag,
@@ -124,6 +126,10 @@ impl WlClipboardListener {
             .lock()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Cannot lock queue: {e}")))?;
         loop {
+            if let Some(reason) = self.terminated_reason.take() {
+                return Err(io::Error::new(io::ErrorKind::Other, reason));
+            }
+
             if self.exit_flag.load(std::sync::atomic::Ordering::Relaxed) {
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
@@ -147,6 +153,9 @@ impl WlClipboardListener {
                                 format!("Dispatch pending failed: {e}"),
                             )
                         })?;
+                        if let Some(reason) = self.terminated_reason.take() {
+                            return Err(io::Error::new(io::ErrorKind::Other, reason));
+                        }
                         if self.copied {
                             self.copied = false;
                             break;
@@ -287,8 +296,10 @@ impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()> for WlClip
             ext_data_control_device_v1::Event::DataOffer { id: _id } => {}
             ext_data_control_device_v1::Event::Finished => {
                 if let Some(DataControlDevice::Ext(device)) = state.data_device.take() {
+                    eprintln!("Wayland ext_data_control_v1 device finished; stopping clipboard listener");
                     device.destroy();
                 }
+                state.terminated_reason = Some("Wayland ext_data_control_v1 device finished");
             }
             ext_data_control_device_v1::Event::PrimarySelection { id } => {
                 if let Some(offer) = id {
@@ -370,8 +381,10 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for WlCl
             zwlr_data_control_device_v1::Event::DataOffer { id: _id } => {}
             zwlr_data_control_device_v1::Event::Finished => {
                 if let Some(DataControlDevice::Zwlr(device)) = state.data_device.take() {
+                    eprintln!("Wayland zwlr_data_control_v1 device finished; stopping clipboard listener");
                     device.destroy();
                 }
+                state.terminated_reason = Some("Wayland zwlr_data_control_v1 device finished");
             }
             zwlr_data_control_device_v1::Event::PrimarySelection { id } => {
                 if let Some(offer) = id {

--- a/src/master/wayland.rs
+++ b/src/master/wayland.rs
@@ -20,6 +20,12 @@ use wayland_protocols_wlr::data_control::v1::client::{
     zwlr_data_control_source_v1,
 };
 
+const WL_SEAT_NAME_VERSION: u32 = 2;
+
+fn bind_version<I: Proxy>(advertised_version: u32) -> u32 {
+    advertised_version.min(I::interface().version)
+}
+
 #[derive(Debug)]
 pub(crate) struct ClipBoardListenMessage {
     pub _mime_types: Vec<String>,
@@ -195,14 +201,26 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListener {
         } = event
         {
             if interface == wl_seat::WlSeat::interface().name {
-                state.seat = Some(registry.bind::<wl_seat::WlSeat, _, _>(name, version, qh, ()));
+                if version >= WL_SEAT_NAME_VERSION && state.seat.is_none() {
+                    state.seat = Some(registry.bind::<wl_seat::WlSeat, _, _>(
+                        name,
+                        bind_version::<wl_seat::WlSeat>(WL_SEAT_NAME_VERSION),
+                        qh,
+                        (),
+                    ));
+                }
             } else if interface
                 == ext_data_control_manager_v1::ExtDataControlManagerV1::interface().name
             {
                 // Prefer ext protocol (standard, supported by Plasma 6.5+, wlroots 0.18+)
                 state.data_manager = Some(DataControlManager::Ext(
                     registry.bind::<ext_data_control_manager_v1::ExtDataControlManagerV1, _, _>(
-                        name, version, qh, (),
+                        name,
+                        bind_version::<ext_data_control_manager_v1::ExtDataControlManagerV1>(
+                            version,
+                        ),
+                        qh,
+                        (),
                     ),
                 ));
             } else if interface
@@ -213,7 +231,12 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListener {
                     state.data_manager = Some(DataControlManager::Zwlr(
                         registry
                             .bind::<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, _, _>(
-                                name, version, qh, (),
+                                name,
+                                bind_version::<
+                                    zwlr_data_control_manager_v1::ZwlrDataControlManagerV1,
+                                >(version),
+                                qh,
+                                (),
                             ),
                     ));
                 }
@@ -258,16 +281,13 @@ impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()> for WlClip
         event: <ext_data_control_device_v1::ExtDataControlDeviceV1 as Proxy>::Event,
         _data: &(),
         _conn: &Connection,
-        qh: &wayland_client::QueueHandle<Self>,
+        _qhandle: &wayland_client::QueueHandle<Self>,
     ) {
         match event {
             ext_data_control_device_v1::Event::DataOffer { id: _id } => {}
             ext_data_control_device_v1::Event::Finished => {
-                if let Some(DataControlManager::Ext(dm)) = state.data_manager.as_ref() {
-                    let source = dm.create_data_source(qh, ());
-                    if let Some(DataControlDevice::Ext(dd)) = state.data_device.as_ref() {
-                        dd.set_selection(Some(&source));
-                    }
+                if let Some(DataControlDevice::Ext(device)) = state.data_device.take() {
+                    device.destroy();
                 }
             }
             ext_data_control_device_v1::Event::PrimarySelection { id } => {
@@ -344,16 +364,13 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for WlCl
         event: <zwlr_data_control_device_v1::ZwlrDataControlDeviceV1 as Proxy>::Event,
         _data: &(),
         _conn: &Connection,
-        qh: &wayland_client::QueueHandle<Self>,
+        _qhandle: &wayland_client::QueueHandle<Self>,
     ) {
         match event {
             zwlr_data_control_device_v1::Event::DataOffer { id: _id } => {}
             zwlr_data_control_device_v1::Event::Finished => {
-                if let Some(DataControlManager::Zwlr(dm)) = state.data_manager.as_ref() {
-                    let source = dm.create_data_source(qh, ());
-                    if let Some(DataControlDevice::Zwlr(dd)) = state.data_device.as_ref() {
-                        dd.set_selection(Some(&source));
-                    }
+                if let Some(DataControlDevice::Zwlr(device)) = state.data_device.take() {
+                    device.destroy();
                 }
             }
             zwlr_data_control_device_v1::Event::PrimarySelection { id } => {

--- a/src/master/wayland.rs
+++ b/src/master/wayland.rs
@@ -1,4 +1,5 @@
 // Derived from https://github.com/Decodetalkers/wayland-clipboard-listener/blob/master/src/dispatch.rs
+// Extended to support both ext_data_control_v1 (preferred) and zwlr_data_control_v1 (fallback).
 
 use std::{
     io,
@@ -10,6 +11,10 @@ use wayland_client::{
     protocol::{wl_registry, wl_seat},
     Connection, Dispatch, EventQueue, Proxy,
 };
+use wayland_protocols::ext::data_control::v1::client::{
+    ext_data_control_device_v1, ext_data_control_manager_v1, ext_data_control_offer_v1,
+    ext_data_control_source_v1,
+};
 use wayland_protocols_wlr::data_control::v1::client::{
     zwlr_data_control_device_v1, zwlr_data_control_manager_v1, zwlr_data_control_offer_v1,
     zwlr_data_control_source_v1,
@@ -20,11 +25,21 @@ pub(crate) struct ClipBoardListenMessage {
     pub _mime_types: Vec<String>,
 }
 
+enum DataControlManager {
+    Ext(ext_data_control_manager_v1::ExtDataControlManagerV1),
+    Zwlr(zwlr_data_control_manager_v1::ZwlrDataControlManagerV1),
+}
+
+enum DataControlDevice {
+    Ext(ext_data_control_device_v1::ExtDataControlDeviceV1),
+    Zwlr(zwlr_data_control_device_v1::ZwlrDataControlDeviceV1),
+}
+
 pub(crate) struct WlClipboardListener {
     seat: Option<wl_seat::WlSeat>,
     seat_name: Option<String>,
-    data_manager: Option<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1>,
-    data_device: Option<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1>,
+    data_manager: Option<DataControlManager>,
+    data_device: Option<DataControlDevice>,
     mime_types: Vec<String>,
     queue: Option<Arc<Mutex<EventQueue<Self>>>>,
     exit_flag: Arc<AtomicBool>,
@@ -60,7 +75,7 @@ impl WlClipboardListener {
         if !state.device_ready() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "Cannot get seat and data manager",
+                "Cannot get seat and data manager (neither ext_data_control_v1 nor zwlr_data_control_v1 available)",
             ));
         }
         while state.seat_name.is_none() {
@@ -80,9 +95,13 @@ impl WlClipboardListener {
 
     fn set_data_device(&mut self, qh: &wayland_client::QueueHandle<Self>) {
         match (self.seat.as_ref(), self.data_manager.as_ref()) {
-            (Some(seat), Some(manager)) => {
+            (Some(seat), Some(DataControlManager::Ext(manager))) => {
                 let device = manager.get_data_device(seat, qh, ());
-                self.data_device = Some(device);
+                self.data_device = Some(DataControlDevice::Ext(device));
+            }
+            (Some(seat), Some(DataControlManager::Zwlr(manager))) => {
+                let device = manager.get_data_device(seat, qh, ());
+                self.data_device = Some(DataControlDevice::Zwlr(device));
             }
             _ => {}
         }
@@ -158,6 +177,8 @@ impl Iterator for WlClipboardListener {
     }
 }
 
+// --- Registry dispatch: prefer ext_data_control_v1, fall back to zwlr_data_control_v1 ---
+
 impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListener {
     fn event(
         state: &mut Self,
@@ -176,16 +197,26 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListener {
             if interface == wl_seat::WlSeat::interface().name {
                 state.seat = Some(registry.bind::<wl_seat::WlSeat, _, _>(name, version, qh, ()));
             } else if interface
+                == ext_data_control_manager_v1::ExtDataControlManagerV1::interface().name
+            {
+                // Prefer ext protocol (standard, supported by Plasma 6.5+, wlroots 0.18+)
+                state.data_manager = Some(DataControlManager::Ext(
+                    registry.bind::<ext_data_control_manager_v1::ExtDataControlManagerV1, _, _>(
+                        name, version, qh, (),
+                    ),
+                ));
+            } else if interface
                 == zwlr_data_control_manager_v1::ZwlrDataControlManagerV1::interface().name
             {
-                state.data_manager = Some(
-                    registry.bind::<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, _, _>(
-                        name,
-                        version,
-                        qh,
-                        (),
-                    ),
-                );
+                // Only use zwlr if ext is not already bound
+                if !matches!(state.data_manager, Some(DataControlManager::Ext(_))) {
+                    state.data_manager = Some(DataControlManager::Zwlr(
+                        registry
+                            .bind::<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, _, _>(
+                                name, version, qh, (),
+                            ),
+                    ));
+                }
             }
         }
     }
@@ -205,6 +236,94 @@ impl Dispatch<wl_seat::WlSeat, ()> for WlClipboardListener {
         }
     }
 }
+
+// --- ext_data_control_v1 dispatch implementations ---
+
+impl Dispatch<ext_data_control_manager_v1::ExtDataControlManagerV1, ()> for WlClipboardListener {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ext_data_control_manager_v1::ExtDataControlManagerV1,
+        _event: <ext_data_control_manager_v1::ExtDataControlManagerV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &wayland_client::Connection,
+        _qhandle: &wayland_client::QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()> for WlClipboardListener {
+    fn event(
+        state: &mut Self,
+        _proxy: &ext_data_control_device_v1::ExtDataControlDeviceV1,
+        event: <ext_data_control_device_v1::ExtDataControlDeviceV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        qh: &wayland_client::QueueHandle<Self>,
+    ) {
+        match event {
+            ext_data_control_device_v1::Event::DataOffer { id: _id } => {}
+            ext_data_control_device_v1::Event::Finished => {
+                if let Some(DataControlManager::Ext(dm)) = state.data_manager.as_ref() {
+                    let source = dm.create_data_source(qh, ());
+                    if let Some(DataControlDevice::Ext(dd)) = state.data_device.as_ref() {
+                        dd.set_selection(Some(&source));
+                    }
+                }
+            }
+            ext_data_control_device_v1::Event::PrimarySelection { id } => {
+                if let Some(offer) = id {
+                    offer.destroy();
+                }
+            }
+            ext_data_control_device_v1::Event::Selection { id } => {
+                let Some(_offer) = id else {
+                    return;
+                };
+                state.copied = true;
+            }
+            _ => {}
+        }
+    }
+    event_created_child!(WlClipboardListener, ext_data_control_device_v1::ExtDataControlDeviceV1, [
+        ext_data_control_device_v1::EVT_DATA_OFFER_OPCODE => (ext_data_control_offer_v1::ExtDataControlOfferV1, ())
+    ]);
+}
+
+impl Dispatch<ext_data_control_source_v1::ExtDataControlSourceV1, ()> for WlClipboardListener {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ext_data_control_source_v1::ExtDataControlSourceV1,
+        event: <ext_data_control_source_v1::ExtDataControlSourceV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &wayland_client::QueueHandle<Self>,
+    ) {
+        match event {
+            ext_data_control_source_v1::Event::Send {
+                fd: _fd,
+                mime_type: _mime_type,
+            } => {}
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ext_data_control_offer_v1::ExtDataControlOfferV1, ()> for WlClipboardListener {
+    fn event(
+        state: &mut Self,
+        _proxy: &ext_data_control_offer_v1::ExtDataControlOfferV1,
+        event: <ext_data_control_offer_v1::ExtDataControlOfferV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &wayland_client::QueueHandle<Self>,
+    ) {
+        if let ext_data_control_offer_v1::Event::Offer { mime_type } = event {
+            state.mime_types.push(mime_type);
+        }
+    }
+}
+
+// --- zwlr_data_control_v1 dispatch implementations (fallback for older compositors) ---
 
 impl Dispatch<zwlr_data_control_manager_v1::ZwlrDataControlManagerV1, ()> for WlClipboardListener {
     fn event(
@@ -230,15 +349,11 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for WlCl
         match event {
             zwlr_data_control_device_v1::Event::DataOffer { id: _id } => {}
             zwlr_data_control_device_v1::Event::Finished => {
-                if let Some(source) = state
-                    .data_manager
-                    .as_ref()
-                    .map(|dm| dm.create_data_source(qh, ()))
-                {
-                    state
-                        .data_device
-                        .as_ref()
-                        .map(|dd| dd.set_selection(Some(&source)));
+                if let Some(DataControlManager::Zwlr(dm)) = state.data_manager.as_ref() {
+                    let source = dm.create_data_source(qh, ());
+                    if let Some(DataControlDevice::Zwlr(dd)) = state.data_device.as_ref() {
+                        dd.set_selection(Some(&source));
+                    }
                 }
             }
             zwlr_data_control_device_v1::Event::PrimarySelection { id } => {

--- a/src/master/wayland.rs
+++ b/src/master/wayland.rs
@@ -44,6 +44,7 @@ enum DataControlDevice {
 pub(crate) struct WlClipboardListener {
     seat: Option<wl_seat::WlSeat>,
     seat_name: Option<String>,
+    seat_name_supported: bool,
     data_manager: Option<DataControlManager>,
     data_device: Option<DataControlDevice>,
     terminated_reason: Option<&'static str>,
@@ -69,6 +70,7 @@ impl WlClipboardListener {
         let mut state = WlClipboardListener {
             seat: None,
             seat_name: None,
+            seat_name_supported: false,
             data_manager: None,
             data_device: None,
             terminated_reason: None,
@@ -86,10 +88,12 @@ impl WlClipboardListener {
                 "Cannot get seat and data manager (neither ext_data_control_v1 nor zwlr_data_control_v1 available)",
             ));
         }
-        while state.seat_name.is_none() {
-            event_queue.roundtrip(&mut state).map_err(|_| {
-                io::Error::new(io::ErrorKind::Other, "Cannot roundtrip during init")
-            })?;
+        if state.seat_name_supported {
+            while state.seat_name.is_none() {
+                event_queue.roundtrip(&mut state).map_err(|_| {
+                    io::Error::new(io::ErrorKind::Other, "Cannot roundtrip during init")
+                })?;
+            }
         }
 
         state.set_data_device(&qhandle);
@@ -179,7 +183,7 @@ impl WlClipboardListener {
             }
         }
         Ok(ClipBoardListenMessage {
-            _mime_types: self.mime_types.clone(),
+            _mime_types: std::mem::take(&mut self.mime_types),
         })
     }
 }
@@ -210,10 +214,11 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WlClipboardListener {
         } = event
         {
             if interface == wl_seat::WlSeat::interface().name {
-                if version >= WL_SEAT_NAME_VERSION && state.seat.is_none() {
+                if state.seat.is_none() {
+                    state.seat_name_supported = version >= WL_SEAT_NAME_VERSION;
                     state.seat = Some(registry.bind::<wl_seat::WlSeat, _, _>(
                         name,
-                        bind_version::<wl_seat::WlSeat>(WL_SEAT_NAME_VERSION),
+                        bind_version::<wl_seat::WlSeat>(version),
                         qh,
                         (),
                     ));
@@ -307,9 +312,10 @@ impl Dispatch<ext_data_control_device_v1::ExtDataControlDeviceV1, ()> for WlClip
                 }
             }
             ext_data_control_device_v1::Event::Selection { id } => {
-                let Some(_offer) = id else {
+                let Some(offer) = id else {
                     return;
                 };
+                offer.destroy();
                 state.copied = true;
             }
             _ => {}
@@ -392,9 +398,10 @@ impl Dispatch<zwlr_data_control_device_v1::ZwlrDataControlDeviceV1, ()> for WlCl
                 }
             }
             zwlr_data_control_device_v1::Event::Selection { id } => {
-                let Some(_offer) = id else {
+                let Some(offer) = id else {
                     return;
                 };
+                offer.destroy();
                 state.copied = true;
             }
             _ => {

--- a/src/master/x11.rs
+++ b/src/master/x11.rs
@@ -272,6 +272,8 @@ impl<H: ClipboardHandler> Master<H> {
                             );
                             eprintln!("Wayland clipboard listener stopped with error: {}", error);
                             match self.handler.on_clipboard_error(error) {
+                                // The Wayland listener cannot recover once the stream fails, so
+                                // even `Next` means stopping this run loop.
                                 CallbackResult::Next => break,
                                 CallbackResult::Stop => break,
                                 CallbackResult::StopWithError(error) => {
@@ -316,6 +318,8 @@ impl<H: ClipboardHandler> Master<H> {
                         eprintln!("Wayland clipboard listener initialization failed after probe succeeded: {}. Falling back to X11.", error);
                     }
                     Err(WaylandRunError::Runtime(error)) => {
+                        // Runtime failures are reported to the caller instead of silently
+                        // switching backends after the listener has already started.
                         return Err(error);
                     }
                 }

--- a/src/master/x11.rs
+++ b/src/master/x11.rs
@@ -281,15 +281,54 @@ impl<H: ClipboardHandler> Master<H> {
 
    ///Starts Master by waiting for any change
     pub fn run(&mut self) -> io::Result<()> {
-        use wl_clipboard_rs::utils::is_primary_selection_supported;
         if std::env::var_os("WAYLAND_DISPLAY").is_some() {
-            // https://github.com/1Password/arboard/blob/151e679ee5c208403b06ba02d28f92c5891f7867/src/platform/linux/wayland.rs#L50
-            if let Err(error) = is_primary_selection_supported() {
-                println!("Failed to start wayland: {:?}, fall back to x11", error); 
-            } else {
+            // Try to detect if any data control protocol is available.
+            // wl_clipboard_rs::utils::is_primary_selection_supported() only checks
+            // zwlr_data_control_v1 which was removed in KDE Plasma 6.5+.
+            // Our WlClipboardListener::init() handles both ext and zwlr protocols,
+            // so we use a lightweight check: try to connect and probe the registry.
+            if Self::is_wayland_data_control_available() {
                 return self.run_wayland();
             }
+            println!("No wayland data control protocol available, falling back to x11");
         }
         self.run_x11()
+    }
+
+    fn is_wayland_data_control_available() -> bool {
+        use wayland_client::{Connection, Dispatch, Proxy, protocol::wl_registry};
+
+        struct Probe {
+            found: bool,
+        }
+
+        impl Dispatch<wl_registry::WlRegistry, ()> for Probe {
+            fn event(
+                state: &mut Self,
+                _: &wl_registry::WlRegistry,
+                event: <wl_registry::WlRegistry as Proxy>::Event,
+                _: &(),
+                _: &Connection,
+                _: &wayland_client::QueueHandle<Self>,
+            ) {
+                if let wl_registry::Event::Global { interface, .. } = event {
+                    if interface == "ext_data_control_manager_v1"
+                        || interface == "zwlr_data_control_manager_v1"
+                    {
+                        state.found = true;
+                    }
+                }
+            }
+        }
+
+        let Ok(conn) = Connection::connect_to_env() else {
+            return false;
+        };
+        let mut eq = conn.new_event_queue::<Probe>();
+        let qh = eq.handle();
+        conn.display().get_registry(&qh, ());
+        let mut probe = Probe { found: false };
+        let _ = eq.blocking_dispatch(&mut probe);
+        probe.found
     }
 }

--- a/src/master/x11.rs
+++ b/src/master/x11.rs
@@ -279,56 +279,18 @@ impl<H: ClipboardHandler> Master<H> {
         result
     }
 
-   ///Starts Master by waiting for any change
+    ///Starts Master by waiting for any change
     pub fn run(&mut self) -> io::Result<()> {
+        use wl_clipboard_rs::utils::is_primary_selection_supported;
+
         if std::env::var_os("WAYLAND_DISPLAY").is_some() {
-            // Try to detect if any data control protocol is available.
-            // wl_clipboard_rs::utils::is_primary_selection_supported() only checks
-            // zwlr_data_control_v1 which was removed in KDE Plasma 6.5+.
-            // Our WlClipboardListener::init() handles both ext and zwlr protocols,
-            // so we use a lightweight check: try to connect and probe the registry.
-            if Self::is_wayland_data_control_available() {
-                return self.run_wayland();
-            }
-            println!("No wayland data control protocol available, falling back to x11");
-        }
-        self.run_x11()
-    }
-
-    fn is_wayland_data_control_available() -> bool {
-        use wayland_client::{Connection, Dispatch, Proxy, protocol::wl_registry};
-
-        struct Probe {
-            found: bool,
-        }
-
-        impl Dispatch<wl_registry::WlRegistry, ()> for Probe {
-            fn event(
-                state: &mut Self,
-                _: &wl_registry::WlRegistry,
-                event: <wl_registry::WlRegistry as Proxy>::Event,
-                _: &(),
-                _: &Connection,
-                _: &wayland_client::QueueHandle<Self>,
-            ) {
-                if let wl_registry::Event::Global { interface, .. } = event {
-                    if interface == "ext_data_control_manager_v1"
-                        || interface == "zwlr_data_control_manager_v1"
-                    {
-                        state.found = true;
-                    }
+            match is_primary_selection_supported() {
+                Ok(_) => return self.run_wayland(),
+                Err(error) => {
+                    println!("Failed to start wayland: {:?}, fall back to x11", error);
                 }
             }
         }
-
-        let Ok(conn) = Connection::connect_to_env() else {
-            return false;
-        };
-        let mut eq = conn.new_event_queue::<Probe>();
-        let qh = eq.handle();
-        conn.display().get_registry(&qh, ());
-        let mut probe = Probe { found: false };
-        let _ = eq.blocking_dispatch(&mut probe);
-        probe.found
+        self.run_x11()
     }
 }

--- a/src/master/x11.rs
+++ b/src/master/x11.rs
@@ -37,6 +37,11 @@ pub struct Master<H> {
     recv: Arc<Mutex<Receiver<()>>>
 }
 
+enum WaylandRunError {
+    Init(io::Error),
+    Runtime(io::Error),
+}
+
 impl<H: ClipboardHandler> Master<H> {
     #[inline(always)]
     ///Creates new instance.
@@ -227,7 +232,7 @@ impl<H: ClipboardHandler> Master<H> {
         CLIP.get_or_init(x11_clipboard::Clipboard::new)
     }
 
-    fn run_wayland(&mut self) -> io::Result<()> {
+    fn run_wayland(&mut self) -> Result<(), WaylandRunError> {
         let exit_flag = Arc::new(AtomicBool::new(false));
         let exit_flag_clone = exit_flag.clone();
 
@@ -254,13 +259,31 @@ impl<H: ClipboardHandler> Master<H> {
         use super::wayland::WlClipboardListener;
         match WlClipboardListener::init(exit_flag.clone()) {
             Ok(listener) => {
-                for _context in listener.into_iter() {
+                for context in listener.into_iter() {
                     if exit_flag.load(std::sync::atomic::Ordering::Relaxed) {
                         break;
                     }
+                    match context {
+                        Ok(_) => {}
+                        Err(error) => {
+                            let error = io::Error::new(
+                                io::ErrorKind::Other,
+                                format!("Wayland clipboard listener failed: {error}"),
+                            );
+                            eprintln!("Wayland clipboard listener stopped with error: {}", error);
+                            match self.handler.on_clipboard_error(error) {
+                                CallbackResult::Next => break,
+                                CallbackResult::Stop => break,
+                                CallbackResult::StopWithError(error) => {
+                                    result = Err(WaylandRunError::Runtime(error));
+                                    break;
+                                }
+                            }
+                        }
+                    }
                     match self.handler.on_clipboard_change() {
                         CallbackResult::StopWithError(error) => {
-                            result = Err(error);
+                            result = Err(WaylandRunError::Runtime(error));
                             break;
                         }
                         CallbackResult::Stop => {
@@ -271,7 +294,7 @@ impl<H: ClipboardHandler> Master<H> {
                 }
             }
             Err(error) => {
-                result = Err(io::Error::new(io::ErrorKind::Other, error));
+                result = Err(WaylandRunError::Init(io::Error::new(io::ErrorKind::Other, error)));
             }
         }
         listen_tx.send(()).ok();
@@ -279,15 +302,22 @@ impl<H: ClipboardHandler> Master<H> {
         result
     }
 
-    ///Starts Master by waiting for any change
+   ///Starts Master by waiting for any change
     pub fn run(&mut self) -> io::Result<()> {
         use wl_clipboard_rs::utils::is_primary_selection_supported;
-
         if std::env::var_os("WAYLAND_DISPLAY").is_some() {
-            match is_primary_selection_supported() {
-                Ok(_) => return self.run_wayland(),
-                Err(error) => {
-                    println!("Failed to start wayland: {:?}, fall back to x11", error);
+            // https://github.com/1Password/arboard/blob/151e679ee5c208403b06ba02d28f92c5891f7867/src/platform/linux/wayland.rs#L50
+            if let Err(error) = is_primary_selection_supported() {
+                println!("Failed to start wayland: {:?}, fall back to x11", error);
+            } else {
+                match self.run_wayland() {
+                    Ok(()) => return Ok(()),
+                    Err(WaylandRunError::Init(error)) => {
+                        eprintln!("Wayland clipboard listener initialization failed after probe succeeded: {}. Falling back to X11.", error);
+                    }
+                    Err(WaylandRunError::Runtime(error)) => {
+                        return Err(error);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Based on https://github.com/night-hood/clipboard-master/tree/fix/ext-data-control-v1

Adds `ext_data_control_v1` support for Wayland clipboard monitoring while keeping `zwlr_data_control_v1` as a fallback.

It also fixes shutdown and fallback behavior in the Wayland path:
  - Treat `Finished` as terminal and stop using the device
  - fall back to X11 if Wayland init fails after a successful probe
  - forward runtime Wayland listener errors through the existing error callback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Wayland clipboard support to include an additional protocol variant with intelligent fallback mechanism.

* **Bug Fixes**
  * Improved error handling for Wayland initialization and runtime failures with better X11 fallback recovery.

* **Chores**
  * Updated Wayland protocol dependency and enabled additional feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->